### PR TITLE
Johns

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -19,6 +19,12 @@ if (config.password === null && process.env.DB_PASSWORD) {
   config.password = process.env.DB_PASSWORD;
 }
 
+// The API key for Last.fm should be read from a .env file or configured as an
+// environment variable in the case of Heroku.  Assume the existence of an
+// environment variable:
+//   LASTFM_API_KEY
+// and return its value in a property of the exported db.
+db.APIKey_LastFM = process.env.LASTFM_API_KEY;
 /* {{{ **
 ** if (config.use_env_variable) {
 **   var sequelize = new Sequelize(process.env[config.use_env_variable]);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.20.0",
     "bcryptjs": "2.4.3",
     "dotenv": "^8.2.0",
     "express": "^4.17.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "mysql2": "^1.6.5",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
+    "querystring": "^0.2.0",
     "sequelize": "^5.8.6"
   },
   "devDependencies": {

--- a/routes/lastFm-api-routes.js
+++ b/routes/lastFm-api-routes.js
@@ -1,0 +1,141 @@
+const querystring = require("querystring");
+
+module.exports = function(app, apiKey) {
+  //search() methods require only one field and return array
+  //
+  //Test QueryURL: {{{
+  //https://ws.audioscrobbler.com/2.0/?method=album.search&api_key=0f24baaf97d9f361f1298f967467d650&album=Believe&format=json
+  //______________ }}}
+  app.get("/api/lastfm/search/album/:album", (req, res) => {
+    const queryObj = {
+      url: "https://ws.audioscrobbler.com/2.0/?",
+      method: "album.search",
+      appid: apiKey,
+      album: "",
+      format: "json"
+    };
+    queryObj.album = req.param.album;
+    const queryURL = querystring.stringify(queryObj);
+    $.ajax({
+      url: queryURL,
+      method: "GET"
+    }).then(response => {
+      // Data is already returned in JSON format so just use .send()
+      res.send(response);
+    });
+  });
+  //Test QueryURL: {{{
+  //https://ws.audioscrobbler.com/2.0/?method=artist.search&api_key=0f24baaf97d9f361f1298f967467d650&artist=Cher&format=json
+  //______________ }}}
+  //
+  app.get("/api/lastfm/search/artist/:artist", (req, res) => {
+    const queryObj = {
+      url: "https://ws.audioscrobbler.com/2.0/?",
+      method: "artist.getinfo",
+      appid: apiKey,
+      artist: "",
+      format: "json"
+    };
+    queryObj.artist = req.param.artist;
+    const queryURL = querystring.stringify(queryObj);
+    $.ajax({
+      url: queryURL,
+      method: "GET"
+    }).then(response => {
+      // Data is already returned in JSON format so just use .send()
+      res.send(response);
+    });
+  });
+  //Test QueryURL: {{{
+  //https://ws.audioscrobbler.com/2.0/?method=track.search&api_key=0f24baaf97d9f361f1298f967467d650&track=believe&format=json
+  //______________ }}}
+  app.get("/api/lastfm/getinfo/song/:song", (req, res) => {
+    const queryObj = {
+      url: "https://ws.audioscrobbler.com/2.0/?",
+      method: "track.getinfo",
+      appid: apiKey,
+      track: "",
+      format: "json"
+    };
+    queryObj.track = req.param.song;
+    const queryURL = querystring.stringify(queryObj);
+    $.ajax({
+      url: queryURL,
+      method: "GET"
+    }).then(response => {
+      // Data is already returned in JSON format so just use .send()
+      res.send(response);
+    });
+  });
+  //getInfo() methods require only one field and return array
+  //
+  //Test QueryURL: {{{
+  //https://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key=0f24baaf97d9f361f1298f967467d650&artist=Cher&album=Believe&format=json
+  //______________ }}}
+  app.get("/api/lastfm/getinfo/album/:album/:artist", (req, res) => {
+    const queryObj = {
+      url: "https://ws.audioscrobbler.com/2.0/?",
+      method: "album.getinfo",
+      appid: apiKey,
+      artist: "",
+      album: "",
+      format: "json"
+    };
+    queryObj.artist = req.param.artist;
+    queryObj.album = req.param.album;
+    const queryURL = querystring.stringify(queryObj);
+    $.ajax({
+      url: queryURL,
+      method: "GET"
+    }).then(response => {
+      // Data is already returned in JSON format so just use .send()
+      res.send(response);
+    });
+  });
+  //Test QueryURL: {{{
+  //https://ws.audioscrobbler.com/2.0/?method=artist.getinfo&api_key=0f24baaf97d9f361f1298f967467d650&artist=Cher&format=json
+  //______________ }}}
+  //
+  app.get("/api/lastfm/getinfo/artist/:artist", (req, res) => {
+    const queryObj = {
+      url: "https://ws.audioscrobbler.com/2.0/?",
+      method: "artist.getinfo",
+      appid: apiKey,
+      album: "",
+      artist: "",
+      format: "json"
+    };
+    queryObj.artist = req.param.artist;
+    const queryURL = querystring.stringify(queryObj);
+    $.ajax({
+      url: queryURL,
+      method: "GET"
+    }).then(response => {
+      // Data is already returned in JSON format so just use .send()
+      res.send(response);
+    });
+  });
+  //Test QueryURL: {{{
+  //https://ws.audioscrobbler.com/2.0/?method=track.getinfo&api_key=0f24baaf97d9f361f1298f967467d650&artist=Cher&track=believe&format=json
+  //______________ }}}
+  app.get("/api/lastfm/getinfo/song/:song/:artist", (req, res) => {
+    const queryObj = {
+      url: "https://ws.audioscrobbler.com/2.0/?",
+      method: "track.getinfo",
+      appid: apiKey,
+      artist: "",
+      track: "",
+      format: "json"
+    };
+    queryObj.artist = req.param.artist;
+    queryObj.track = req.param.song;
+    const queryURL = querystring.stringify(queryObj);
+    $.ajax({
+      url: queryURL,
+      method: "GET"
+    }).then(response => {
+      // Data is already returned in JSON format so just use .send()
+      res.send(response);
+    });
+  });
+};

--- a/routes/lastFm-api-routes.js
+++ b/routes/lastFm-api-routes.js
@@ -1,4 +1,11 @@
+const axios = require("axios");
 const querystring = require("querystring");
+
+// The lastFM API requires a parameter in snake case rather than camel case so
+// add a c-style comment ESLint will check; yes a c-style comment is required.
+// Do not comment this line out with a nested c-style comment!
+//
+/* eslint-disable camelcase */
 
 module.exports = function(app, apiKey) {
   //search() methods require only one field and return array
@@ -7,65 +14,80 @@ module.exports = function(app, apiKey) {
   //https://ws.audioscrobbler.com/2.0/?method=album.search&api_key=0f24baaf97d9f361f1298f967467d650&album=Believe&format=json
   //______________ }}}
   app.get("/api/lastfm/search/album/:album", (req, res) => {
+    const baseUrl = "https://ws.audioscrobbler.com/2.0/?";
     const queryObj = {
-      url: "https://ws.audioscrobbler.com/2.0/?",
       method: "album.search",
-      appid: apiKey,
+      api_key: apiKey,
       album: "",
       format: "json"
     };
-    queryObj.album = req.param.album;
-    const queryURL = querystring.stringify(queryObj);
-    $.ajax({
-      url: queryURL,
-      method: "GET"
-    }).then(response => {
-      // Data is already returned in JSON format so just use .send()
-      res.send(response);
-    });
+    queryObj.album = req.params.album;
+    const queryURL = baseUrl + querystring.stringify(queryObj);
+    console.log("Last.fm queryURL=\n" + queryURL);
+    axios
+      .get(queryURL)
+      .then(response => {
+        // Data is already returned in JSON format so just use .send()
+        // and only return the data property from the complete response
+        res.send(response.data);
+      })
+      .catch(error => {
+        console.log(error);
+        res.send(error);
+      });
   });
   //Test QueryURL: {{{
   //https://ws.audioscrobbler.com/2.0/?method=artist.search&api_key=0f24baaf97d9f361f1298f967467d650&artist=Cher&format=json
   //______________ }}}
   //
   app.get("/api/lastfm/search/artist/:artist", (req, res) => {
+    const baseUrl = "https://ws.audioscrobbler.com/2.0/?";
     const queryObj = {
-      url: "https://ws.audioscrobbler.com/2.0/?",
-      method: "artist.getinfo",
-      appid: apiKey,
+      method: "artist.search",
+      api_key: apiKey,
       artist: "",
       format: "json"
     };
-    queryObj.artist = req.param.artist;
-    const queryURL = querystring.stringify(queryObj);
-    $.ajax({
-      url: queryURL,
-      method: "GET"
-    }).then(response => {
-      // Data is already returned in JSON format so just use .send()
-      res.send(response);
-    });
+    queryObj.artist = req.params.artist;
+    const queryURL = baseUrl + querystring.stringify(queryObj);
+    console.log("Last.fm queryURL=\n" + queryURL);
+    axios
+      .get(queryURL)
+      .then(response => {
+        // Data is already returned in JSON format so just use .send()
+        // and only return the data property from the complete response
+        res.send(response.data);
+      })
+      .catch(error => {
+        console.log(error);
+        res.send(error);
+      });
   });
   //Test QueryURL: {{{
   //https://ws.audioscrobbler.com/2.0/?method=track.search&api_key=0f24baaf97d9f361f1298f967467d650&track=believe&format=json
   //______________ }}}
-  app.get("/api/lastfm/getinfo/song/:song", (req, res) => {
+  app.get("/api/lastfm/search/song/:song", (req, res) => {
+    const baseUrl = "https://ws.audioscrobbler.com/2.0/?";
     const queryObj = {
-      url: "https://ws.audioscrobbler.com/2.0/?",
-      method: "track.getinfo",
-      appid: apiKey,
+      method: "track.search",
+      api_key: apiKey,
       track: "",
       format: "json"
     };
-    queryObj.track = req.param.song;
-    const queryURL = querystring.stringify(queryObj);
-    $.ajax({
-      url: queryURL,
-      method: "GET"
-    }).then(response => {
-      // Data is already returned in JSON format so just use .send()
-      res.send(response);
-    });
+    queryObj.track = req.params.song;
+    const queryURL = baseUrl + querystring.stringify(queryObj);
+    console.log("Last.fm queryURL=\n" + queryURL);
+    axios
+      .get(queryURL)
+      .then(response => {
+        // Data is already returned in JSON format so just use .send()
+        // and only return the data property from the complete response
+        res.send(response.data);
+      })
+      .catch(error => {
+        console.log(error);
+        res.send(error);
+      });
   });
   //getInfo() methods require only one field and return array
   //
@@ -73,69 +95,84 @@ module.exports = function(app, apiKey) {
   //https://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key=0f24baaf97d9f361f1298f967467d650&artist=Cher&album=Believe&format=json
   //______________ }}}
   app.get("/api/lastfm/getinfo/album/:album/:artist", (req, res) => {
+    const baseUrl = "https://ws.audioscrobbler.com/2.0/?";
     const queryObj = {
-      url: "https://ws.audioscrobbler.com/2.0/?",
       method: "album.getinfo",
-      appid: apiKey,
+      api_key: apiKey,
       artist: "",
       album: "",
       format: "json"
     };
-    queryObj.artist = req.param.artist;
-    queryObj.album = req.param.album;
-    const queryURL = querystring.stringify(queryObj);
-    $.ajax({
-      url: queryURL,
-      method: "GET"
-    }).then(response => {
-      // Data is already returned in JSON format so just use .send()
-      res.send(response);
-    });
+    queryObj.artist = req.params.artist;
+    queryObj.album = req.params.album;
+    const queryURL = baseUrl + querystring.stringify(queryObj);
+    console.log("Last.fm queryURL=\n" + queryURL);
+    axios
+      .get(queryURL)
+      .then(response => {
+        // Data is already returned in JSON format so just use .send()
+        // and only return the data property from the complete response
+        res.send(response.data);
+      })
+      .catch(error => {
+        console.log(error);
+        res.send(error);
+      });
   });
   //Test QueryURL: {{{
   //https://ws.audioscrobbler.com/2.0/?method=artist.getinfo&api_key=0f24baaf97d9f361f1298f967467d650&artist=Cher&format=json
   //______________ }}}
   //
   app.get("/api/lastfm/getinfo/artist/:artist", (req, res) => {
+    const baseUrl = "https://ws.audioscrobbler.com/2.0/?";
     const queryObj = {
-      url: "https://ws.audioscrobbler.com/2.0/?",
       method: "artist.getinfo",
-      appid: apiKey,
+      api_key: apiKey,
       album: "",
       artist: "",
       format: "json"
     };
-    queryObj.artist = req.param.artist;
-    const queryURL = querystring.stringify(queryObj);
-    $.ajax({
-      url: queryURL,
-      method: "GET"
-    }).then(response => {
-      // Data is already returned in JSON format so just use .send()
-      res.send(response);
-    });
+    queryObj.artist = req.params.artist;
+    const queryURL = baseUrl + querystring.stringify(queryObj);
+    console.log("Last.fm queryURL=\n" + queryURL);
+    axios
+      .get(queryURL)
+      .then(response => {
+        // Data is already returned in JSON format so just use .send()
+        // and only return the data property from the complete response
+        res.send(response.data);
+      })
+      .catch(error => {
+        console.log(error);
+        res.send(error);
+      });
   });
   //Test QueryURL: {{{
   //https://ws.audioscrobbler.com/2.0/?method=track.getinfo&api_key=0f24baaf97d9f361f1298f967467d650&artist=Cher&track=believe&format=json
   //______________ }}}
   app.get("/api/lastfm/getinfo/song/:song/:artist", (req, res) => {
+    const baseUrl = "https://ws.audioscrobbler.com/2.0/?";
     const queryObj = {
-      url: "https://ws.audioscrobbler.com/2.0/?",
       method: "track.getinfo",
-      appid: apiKey,
+      api_key: apiKey,
       artist: "",
       track: "",
       format: "json"
     };
-    queryObj.artist = req.param.artist;
-    queryObj.track = req.param.song;
-    const queryURL = querystring.stringify(queryObj);
-    $.ajax({
-      url: queryURL,
-      method: "GET"
-    }).then(response => {
-      // Data is already returned in JSON format so just use .send()
-      res.send(response);
-    });
+    queryObj.artist = req.params.artist;
+    queryObj.track = req.params.song;
+    const queryURL = baseUrl + querystring.stringify(queryObj);
+    console.log("Last.fm queryURL=\n" + queryURL);
+    axios
+      .get(queryURL)
+      .then(response => {
+        // Data is already returned in JSON format so just use .send()
+        // and only return the data property from the complete response
+        res.send(response.data);
+      })
+      .catch(error => {
+        console.log(error);
+        res.send(error);
+      });
   });
 };

--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@ app.use(passport.session());
 // Requiring our routes
 require("./routes/html-routes.js")(app);
 require("./routes/api-routes.js")(app);
+require("./routes/lastFm-api-routes.js")(app, db.APIKey_LastFM);
 
 // Syncing our database and logging a message to the user upon success
 db.sequelize


### PR DESCRIPTION
The front end will need to gather information using Last.fm API calls, so add `routes/lastFm-api-routes.js` requiring modules `querystring` and `axios` to provide six routes, two each for album, artist, and song:

1. `/api/lastfm/search/album/:album`
1. `/api/lastfm/search/artist/:artist`
1. `/api/lastfm/search/song/:song`
1. `/api/lastfm/getinfo/album/:album/:artist`
1. `/api/lastfm/getinfo/artist/:artist`
1. `/api/lastfm/getinfo/song/:song/:artist`

These API calls were tested with Postman and should be working as long as the .env hidden file provides the API key.  The search() API calls return an array of possible matches, while the getinfo() API calls return more information, but usually need more more search parameters.

Note that `lastFm-api-routes.js` is using a special comment at top to disable the camel case requirement for that file, since the `api_key` parameter is required by Last.fm and does not fit this naming convention. 