### PR TITLE
Remove reference to artists table from notation table

### DIFF
--- a/models/notation.js
+++ b/models/notation.js
@@ -8,14 +8,9 @@ module.exports = function(sequelize, DataTypes) {
   });
 
   Notation.associate = function(models) {
-    // A Notation should belong either to an Album, an Artist, or a Song
+    // A Notation should belong either to an Album or a Song
     // There are not firm foreign key constraints since multiple join points are possible
     Notation.belongsTo(models.Album, {
-      foreignKey: {
-        allowNull: true
-      }
-    });
-    Notation.belongsTo(models.Artist, {
       foreignKey: {
         allowNull: true
       }

--- a/routes/lastFm-api-routes.js
+++ b/routes/lastFm-api-routes.js
@@ -128,7 +128,6 @@ module.exports = function(app, apiKey) {
     const queryObj = {
       method: "artist.getinfo",
       api_key: apiKey,
-      album: "",
       artist: "",
       format: "json"
     };
@@ -161,6 +160,118 @@ module.exports = function(app, apiKey) {
     };
     queryObj.artist = req.params.artist;
     queryObj.track = req.params.song;
+    const queryURL = baseUrl + querystring.stringify(queryObj);
+    console.log("Last.fm queryURL=\n" + queryURL);
+    axios
+      .get(queryURL)
+      .then(response => {
+        // Data is already returned in JSON format so just use .send()
+        // and only return the data property from the complete response
+        res.send(response.data);
+      })
+      .catch(error => {
+        console.log(error);
+        res.send(error);
+      });
+  });
+  //Test QueryURL: {{{
+  //https://ws.audioscrobbler.com/2.0/?method=artist.getsimilar&api_key=0f24baaf97d9f361f1298f967467d650&artist=Cher&format=json
+  //______________ }}}
+  //getSimilar() methods
+  //
+  app.get("/api/lastfm/getsimilar/artist/:artist", (req, res) => {
+    const baseUrl = "https://ws.audioscrobbler.com/2.0/?";
+    const queryObj = {
+      method: "artist.getsimilar",
+      api_key: apiKey,
+      artist: "",
+      format: "json"
+    };
+    queryObj.artist = req.params.artist;
+    const queryURL = baseUrl + querystring.stringify(queryObj);
+    console.log("Last.fm queryURL=\n" + queryURL);
+    axios
+      .get(queryURL)
+      .then(response => {
+        // Data is already returned in JSON format so just use .send()
+        // and only return the data property from the complete response
+        res.send(response.data);
+      })
+      .catch(error => {
+        console.log(error);
+        res.send(error);
+      });
+  });
+  //Test QueryURL: {{{
+  //https://ws.audioscrobbler.com/2.0/?method=track.getsimilar&api_key=0f24baaf97d9f361f1298f967467d650&artist=Cher&track=believe&format=json
+  //______________ }}}
+  app.get("/api/lastfm/getsimilar/song/:song/:artist", (req, res) => {
+    const baseUrl = "https://ws.audioscrobbler.com/2.0/?";
+    const queryObj = {
+      method: "track.getsimilar",
+      api_key: apiKey,
+      artist: "",
+      track: "",
+      format: "json"
+    };
+    queryObj.artist = req.params.artist;
+    queryObj.track = req.params.song;
+    const queryURL = baseUrl + querystring.stringify(queryObj);
+    console.log("Last.fm queryURL=\n" + queryURL);
+    axios
+      .get(queryURL)
+      .then(response => {
+        // Data is already returned in JSON format so just use .send()
+        // and only return the data property from the complete response
+        res.send(response.data);
+      })
+      .catch(error => {
+        console.log(error);
+        res.send(error);
+      });
+  });
+  //Test QueryURL: {{{
+  //https://ws.audioscrobbler.com/2.0/?method=artist.gettopalbums&api_key=0f24baaf97d9f361f1298f967467d650&artist=Cher&format=json
+  //______________ }}}
+  //gettopalbums() method
+  //
+  app.get("/api/lastfm/gettopalbums/artist/:artist", (req, res) => {
+    const baseUrl = "https://ws.audioscrobbler.com/2.0/?";
+    const queryObj = {
+      method: "artist.gettopalbums",
+      api_key: apiKey,
+      artist: "",
+      format: "json"
+    };
+    queryObj.artist = req.params.artist;
+    const queryURL = baseUrl + querystring.stringify(queryObj);
+    console.log("Last.fm queryURL=\n" + queryURL);
+    axios
+      .get(queryURL)
+      .then(response => {
+        // Data is already returned in JSON format so just use .send()
+        // and only return the data property from the complete response
+        res.send(response.data);
+      })
+      .catch(error => {
+        console.log(error);
+        res.send(error);
+      });
+  });
+  //Test QueryURL: {{{
+  //https://ws.audioscrobbler.com/2.0/?method=artist.gettoptracks&api_key=0f24baaf97d9f361f1298f967467d650&artist=Cher&format=json
+  //______________ }}}
+  //gettoptracks() method
+  //
+  app.get("/api/lastfm/gettoptracks/artist/:artist", (req, res) => {
+    const baseUrl = "https://ws.audioscrobbler.com/2.0/?";
+    const queryObj = {
+      method: "artist.gettoptracks",
+      api_key: apiKey,
+      artist: "",
+      format: "json"
+    };
+    queryObj.artist = req.params.artist;
     const queryURL = baseUrl + querystring.stringify(queryObj);
     console.log("Last.fm queryURL=\n" + queryURL);
     axios


### PR DESCRIPTION
Sorry, I forgot to commit the changes removing artists from the notation table.  This mistake actually cases a Sequelize error, so you will want to merge this change before using the new database structure.

I added four more Last.fm API calls that might be needed:
/api/lastfm/getsimilar/artist/:artist
/api/lastfm/getsimilar/song/:song/:artist
/api/lastfm/gettopalbums/artist/:artist
/api/lastfm/gettoptracks/artist/:artist